### PR TITLE
Add card event data

### DIFF
--- a/DriverCardData.config
+++ b/DriverCardData.config
@@ -47,8 +47,24 @@
 	
 	<ElementaryFile Name="CardDownload" Identifier="0x050E"/>
 	<ElementaryFile Name="DrivingLicenceInfo" Identifier="0x0521"/>
-	<ElementaryFile Name="EventsData" Identifier="0x0502"/>
-	<ElementaryFile Name="FaultsData" Identifier="0x0503"/>
+
+  <ElementaryFile Name="EventsData" Identifier="0x0502">
+    <Repeat Name="CardEventRecords" Count="6">
+      <Repeat Name ="CardEventRecordCollection" CountRef="#NoOfEventsPerType">
+        <Object Name="CardEventRecord">
+          <HexValue Name="eventType" Length="1" />
+          <TimeReal Name="eventBeginTime"/>
+          <TimeReal Name="eventEndTime"/>
+          <Object Name="VehicleRegistration">
+            <UInt8 Name="VehicleRegistrationNation"/>
+            <InternationalString Name="VehicleRegistrationNumber" Length="13"/>
+          </Object>
+        </Object>
+      </Repeat>
+    </Repeat>
+  </ElementaryFile>
+
+  <ElementaryFile Name="FaultsData" Identifier="0x0503"/>
 	<ElementaryFile Name="DriverActivityData" Identifier="0x0504">
 		<Cycle Name="DriverCardActivity">
 			<DriverCardDailyActivity Name="ActivityDailyData"/>


### PR DESCRIPTION
Note that this section consists of 6 x NoOfEventsPerType. Currently you are likely to get a number of records with type 0 and no other data. These need filtering out downstream.