### PR TITLE
Fix VehicleRegistrationIdentification for VehicleUnitData

### DIFF
--- a/VehicleUnitData.config
+++ b/VehicleUnitData.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <DataFile Name="Tachodata">
 	<IdentifiedObject Name="TransferDataOverview" Identifier="0x7601">
 		<Padding Name="MemberStateCertificate" Size="194"/>
@@ -58,7 +58,7 @@
 				<Object Name="PreviousVehicleInfo">
 					<Object Name="VehicleRegistrationIdentification">
 						<UInt8 Name="VehicleRegistrationNation"/>
-						<SimpleString Name="VehicleRegistrationNumber" Length="14"/>
+						<InternationalString Name="VehicleRegistrationNumber" Length="13"/>
 					</Object>
 					<TimeReal Name="CardWithdrawalTime"/>
 				</Object>
@@ -160,18 +160,18 @@
 				<SimpleString Name="VehicleIdentificationNumber" Length="17"/>
 				<Object Name="VehicleRegistrationIdentification">
 					<UInt8 Name="VehicleRegistrationNation"/>
-					<SimpleString Name="VehicleRegistrationNumber" Length="14"/>
-					<UInt16 Name="VehicleCharacteristicConstant"/>
-					<UInt16 Name="ConstantOfRecordingEquipment"/>
-					<UInt16 Name="TyreCircumference"/>
-					<SimpleString Name="TyreSize" Length="15"/>
-					<UInt8 Name="AuthorisedSpeed"/>
-					<UInt24 Name="OldOdometerValue"/>
-					<UInt24 Name="NewOdometerValue"/>
-					<TimeReal Name="OldTimeValue"/>
-					<TimeReal Name="NewTimeValue"/>
-					<TimeReal Name="NextCalibrationDate"/>
+					<InternationalString Name="VehicleRegistrationNumber" Length="13"/>
 				</Object>
+				<UInt16 Name="VehicleCharacteristicConstant"/>
+				<UInt16 Name="ConstantOfRecordingEquipment"/>
+				<UInt16 Name="TyreCircumference"/>
+				<SimpleString Name="TyreSize" Length="15"/>
+				<UInt8 Name="AuthorisedSpeed"/>
+				<UInt24 Name="OldOdometerValue"/>
+				<UInt24 Name="NewOdometerValue"/>
+				<TimeReal Name="OldTimeValue"/>
+				<TimeReal Name="NewTimeValue"/>
+				<TimeReal Name="NextCalibrationDate"/>
 			</Object>
 		</Collection>
 		<Padding Name="Signature" Size="128"/>


### PR DESCRIPTION
`VehicleRegistrationNumber` is `InternationalString` not `SimpleString`

![VehicleRegistrationIdentification](https://user-images.githubusercontent.com/651800/29021576-a2bbfbb4-7b6e-11e7-914e-b6fc5b9ce8d7.png)
