### PR TITLE
Use names which match Tachograph specification

### DIFF
--- a/VehicleUnitData.config
+++ b/VehicleUnitData.config
@@ -9,7 +9,7 @@
 			<InternationalString Name="VehicleRegistrationNumber" Length="13"/>
 		</Object>
 		<TimeReal Name="CurrentDateTime"/>
-		<Object Name="VuDownloadPeriod">
+		<Object Name="VuDownloadablePeriod">
 			<TimeReal Name="MinDownloadableTime"/>
 			<TimeReal Name="MaxDownloadableTime"/>
 		</Object>
@@ -19,19 +19,23 @@
 			<FullCardNumber Name="FullCardNumber"/>
 			<Name Name="CompanyOrWorkshopName"/>
 		</Object>
-		<Collection Name="CompanyLocks">
-			<TimeReal Name="LockInTime"/>
-			<TimeReal Name="LockOutTime"/>
-			<Name Name="CompanyName"/>
-			<Name Name="CompanyAddress"/>
-			<FullCardNumber Name="CompanyCardNumber"/>
+		<Collection Name="VuCompanyLocksData">
+			<Object Name="VuCompanyLocksRecord">
+				<TimeReal Name="LockInTime"/>
+				<TimeReal Name="LockOutTime"/>
+				<Name Name="CompanyName"/>
+				<Name Name="CompanyAddress"/>
+				<FullCardNumber Name="CompanyCardNumber"/>
+			</Object>
 		</Collection>
-		<Collection Name="CompanyControls">
-			<UInt8 Name="ControlType"/>
-			<TimeReal Name="ControlTime"/>
-			<FullCardNumber Name="ControlCardNumber"/>
-			<TimeReal Name="DownloadPeriodBeginTime"/>
-			<TimeReal Name="DownloadPeriodEndTime"/>
+		<Collection Name="VuControlActivityData">
+			<Object Name="VuControlActivityRecord">
+				<UInt8 Name="ControlType"/>
+				<TimeReal Name="ControlTime"/>
+				<FullCardNumber Name="ControlCardNumber"/>
+				<TimeReal Name="DownloadPeriodBeginTime"/>
+				<TimeReal Name="DownloadPeriodEndTime"/>
+			</Object>
 		</Collection>
 		<Padding Name="Signature" Size="128"/>
 	</IdentifiedObject>
@@ -42,8 +46,8 @@
 		<TimeReal Name="ActivityDate"/>
 		<UInt24 Name="OdometerValueMidnight"/>
 		
-		<Collection Name="CardIWData" SizeAlloc="WORD">
-			<Object Name="CardIWRecord">
+		<Collection Name="VuCardIWData" SizeAlloc="WORD">
+			<Object Name="VuCardIWRecord">
 				<Object Name="CardHolderName">
 					<Name Name="Lastname"/>
 					<Name Name="Firstname"/>
@@ -69,21 +73,25 @@
 		<Collection Name="VuActivityDailyData" SizeAlloc="WORD">
 			<ActivityChange Name="ActivityChangeInfo"/>
 		</Collection>
-		
+
 		<Collection Name="VuPlaceDailyWorkPeriodData">
-			<FullCardNumber Name="FullCardNumber"/>
-			<Object Name="PlaceRecord">
-				<TimeReal Name="EntryTime"/>
-				<UInt8 Name="EntryType"/>
-				<UInt8 Name="DailyWorkPeriodCountry"/>
-				<UInt8 Name="DailyWorkPeriodRegion"/>
-				<UInt24 Name="VehicleOdometerValue"/>
+			<Object Name="VuPlaceDailyWorkPeriodRecord">
+				<FullCardNumber Name="FullCardNumber"/>
+				<Object Name="PlaceRecord">
+					<TimeReal Name="EntryTime"/>
+					<UInt8 Name="EntryType"/>
+					<UInt8 Name="DailyWorkPeriodCountry"/>
+					<UInt8 Name="DailyWorkPeriodRegion"/>
+					<UInt24 Name="VehicleOdometerValue"/>
+				</Object>
 			</Object>
 		</Collection>
-		
-		<Collection Name="SpecificConditions" SizeAlloc="WORD">
-			<TimeReal Name="EntryTime"/>
-			<UInt8 Name="Type"/>
+
+		<Collection Name="VuSpecificConditionData" SizeAlloc="WORD">
+			<Object Name="SpecificConditionRecord">
+				<TimeReal Name="EntryTime"/>
+				<UInt8 Name="SpecificConditionType"/>
+			</Object>
 		</Collection>
 
 		<Padding Name="Signature" Size="128"/>


### PR DESCRIPTION
It makes it easier to search by these names/fields in specification. Also I think it's best to match it as close as possible.

![TransferDataOverview](https://user-images.githubusercontent.com/651800/29024909-e945a11c-7b7c-11e7-9d18-fa64adf9d984.png)

![TransferDataActivities](https://user-images.githubusercontent.com/651800/29024950-195db2d6-7b7d-11e7-9c79-530780adb098.png)
