### PR TITLE
Implement proper CodePage handling for strings

### DIFF
--- a/BinaryReader.cs
+++ b/BinaryReader.cs
@@ -47,7 +47,7 @@ namespace DataFileReader
 
 		public string ReadString(int length)
 		{
-			return ReadString(length, Encoding.Default);
+			return ReadString(length, Encoding.ASCII);
 		}
 
 		public string ReadString(int length, Encoding enc)

--- a/DataFile.cs
+++ b/DataFile.cs
@@ -415,7 +415,7 @@ namespace DataFileReader
 		protected override void ProcessInternal(CustomBinaryReader reader, XmlWriter writer)
 		{
 			// we just use the default encoding in the default case
-			this.ProcessInternal(reader, Encoding.Default);
+			this.ProcessInternal(reader, Encoding.ASCII);
 			writer.WriteString(text);
 		}
 
@@ -444,16 +444,22 @@ namespace DataFileReader
 		{
 			// get the codepage
 			codepage=reader.ReadByte();
-			Encoding enc=Encoding.Default;
-			try
+			// codePage specifies the part of the ISO/IEC 8859 used to code this string
+			Encoding enc=Encoding.ASCII;
+			if (codepage > 0 && codepage <= 16)
 			{
-				// try to get the encoding
-				enc=Encoding.GetEncoding(codepage);
-			} 
-			catch ( Exception )
+				try
+				{
+					// when codepage=1 it is ISO-8859-1
+					enc=Encoding.GetEncoding("ISO-8859-" + codepage.ToString());
+				}
+				catch ( Exception e )
+				{
+					WriteLine(LogLevel.WARN, "Failed to work with codepage {0}, '{1}'", codepage, e.Message);
+				}
+			} else
 			{
-				// TODO: H: work out what the code page should be
-				// Console.WriteLine("WARN: Failed to work with codepage {0}, '{1}'", codepage, e.Message);
+				WriteLine(LogLevel.WARN, "Unknown codepage {0}", codepage);
 			}
 			// read string using encoding
 			base.ProcessInternal(reader, enc);


### PR DESCRIPTION
CodePage is not Windows Code Page but it specifies part of ISO/IEC 8859
Also it's totally wrong to use Encoding.Default which is Windows default code page which varies based by Windows Regional Settings and also it's not present in DotNet Core so ASCII is much better as default.

Windows/.NET Code pages https://msdn.microsoft.com/en-us/library/system.text.encoding.aspx#Anchor_5

When CodePage is 7 it means it's `ISO-8859-7`

![VehicleRegistrationNumber](https://user-images.githubusercontent.com/651800/29031767-efa95506-7b97-11e7-87a1-375e6206c673.png)

