### PR TITLE
Strings can be shorter than their specified length

### DIFF
--- a/BinaryReader.cs
+++ b/BinaryReader.cs
@@ -58,6 +58,12 @@ namespace DataFileReader
 			if ( amountRead != length )
 				throw new InvalidOperationException("End of file while reading a string");
 
+			int nullPos = Array.IndexOf(buf, (byte)0x00);
+			if (nullPos >= 0 && nullPos < length)
+			{
+				Array.Resize(ref buf, nullPos);
+			}
+
 			char[] chars=enc.GetChars(buf);
 			return new string(chars);
 		}


### PR DESCRIPTION
![name](https://user-images.githubusercontent.com/651800/29062119-16594602-7c29-11e7-9f29-e494a8145721.png)


Name can be 35 bytes long, but if it's shorter it will contain `null` at end.
