### PR TITLE
Fix codepage encoding support

### DIFF
--- a/DataFile.cs
+++ b/DataFile.cs
@@ -463,16 +463,44 @@ namespace DataFileReader
 	}
 
 	// A string that is prefixed by a code page byte
-	// TODO: H: the codepages in the data are not valid code pages for windows
 	public class CodePageStringRegion : SimpleStringRegion
 	{
-		static Dictionary<string, Encoding> codepages=new Dictionary<string, Encoding>();
+		static Dictionary<string, Encoding> encodingCache = new Dictionary<string, Encoding>();
+		static Dictionary<byte, string> charsetMapping = new Dictionary<byte, string>();
 
 		// private int codepage;
 
 		static CodePageStringRegion() {
 			foreach ( var i in Encoding.GetEncodings() ) {
-				codepages.Add(i.Name, i.GetEncoding());
+				encodingCache.Add(i.Name.ToUpper(), i.GetEncoding());
+			}
+
+			charsetMapping[0] = "ASCII";
+			charsetMapping[1] = "ISO-8859-1";
+			charsetMapping[2] = "ISO-8859-2";
+			charsetMapping[3] = "ISO-8859-3";
+			charsetMapping[5] = "ISO-8859-5";
+			charsetMapping[7] = "ISO-8859-7";
+			charsetMapping[9] = "ISO-8859-9";
+			charsetMapping[13] = "ISO-8859-13";
+			charsetMapping[15] = "ISO-8859-15";
+			charsetMapping[16] = "ISO-8859-16";
+			charsetMapping[80] = "KOI8-R";
+			charsetMapping[85] = "KOI8-U";
+
+			// CodePagesEncodingProvider (System.Text.Encoding.CodePages package) on .NET Core by default (GetEncodings() method) supports only few encodings
+			// https://msdn.microsoft.com/en-us/library/system.text.codepagesencodingprovider.aspx#Anchor_4
+			// but if you call GetEncoding directly by name you can get other encodings too
+			// so here we add those too to our cache
+			foreach (var encodingName in charsetMapping.Values) {
+				if (!encodingCache.ContainsKey(encodingName)) {
+					try {
+						var encoding = Encoding.GetEncoding(encodingName);
+						encodingCache.Add(encodingName, encoding);
+					} catch (ArgumentException e) {
+						Console.WriteLine("Warning! Current platform doesn't support encoding with name {0}\n{1}", encodingName, e.Message);
+					}
+				}
 			}
 		}
 
@@ -489,10 +517,15 @@ namespace DataFileReader
 			// get the codepage
 			var codepage=reader.ReadByte();
 			// codePage specifies the part of the ISO/IEC 8859 used to code this string
-			Encoding enc=codepages.GetValueOrDefault("ISO-8859-"+codepage.ToString(), null);
-			if ( enc == null ) {
+
+			string encodingName = charsetMapping.GetValueOrDefault(codepage, "UNKNOWN");
+			Encoding enc=encodingCache.GetValueOrDefault(encodingName, null);
+			if ( enc == null) {
+				// we want to warn if we didn't recognize codepage because using wrong codepage will cause use of wrong codepoints and thus incorrect data
+				WriteLine(LogLevel.WARN, "Unknown codepage {0}", codepage);
 				enc=Encoding.ASCII;
 			}
+
 			// read string using encoding
 			base.ProcessInternal(reader, enc);
 			writer.WriteString(text);


### PR DESCRIPTION
e7b4047969d2be72f096cd68cd5945836aaf9c06 commit broke encodings
because on .NET Core `Encoding.GetEncodings()` returns them in lowercase

```
1200   utf-16
1201   utf-16BE  
12000  utf-32
12001  utf-32BE
20127  us-ascii
28591  iso-8859-1
65000  utf-7
65001  utf-8
```

and so it wouldn't find them in `codepages` dictionary making use of ASCII encoding instead.

Also on .NET Core using [System.Text.Encoding.CodePages](https://www.nuget.org/packages/System.Text.Encoding.CodePages/)  it returns only these few as it doesn't support others by default, but they can be requested by name like `Encoding.GetEncoding("ISO-8859-2")` which works.



Also can get latest tachograph specification here http://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32016R0799

and from it

![attels](https://user-images.githubusercontent.com/651800/37340213-08cd58be-26c6-11e8-91b5-27f82f8a109c.png)


