### PR TITLE
Correctly group SpecificConditionRecords

### DIFF
--- a/DriverCardData.config
+++ b/DriverCardData.config
@@ -150,9 +150,11 @@
 	</ElementaryFile>
 
 	<ElementaryFile Name="SpecificConditions" Identifier="0x0522">
-		<Repeat Name="SpecificConditionRecord" Count="56">
-			<TimeReal Name="EntryTime" />
-			<UInt8 Name="SpecificConditionType"/>
+		<Repeat Name="SpecificConditionRecords" Count="56">
+			<Object Name="SpecificConditionRecord">
+				<TimeReal Name="EntryTime" />
+				<UInt8 Name="SpecificConditionType"/>
+			</Object>
 		</Repeat>
 	</ElementaryFile>
 


### PR DESCRIPTION
Currently they all are like
```xml
<SpecificConditions>
  <SpecificConditionRecord>
        <EntryTime DateTime=""/>
        <SpecificConditionType>1</SpecificConditionType>
        <EntryTime DateTime=""/>
        <SpecificConditionType>2</SpecificConditionType>
  </SpecificConditionRecord>
</SpecificConditions>
```

this PR fixed it so it's

```xml
<SpecificConditions>
  <SpecificConditionRecords>
    <SpecificConditionRecord>
        <EntryTime DateTime=""/>
        <SpecificConditionType>1</SpecificConditionType>
    </SpecificConditionRecord>
    <SpecificConditionRecord>
        <EntryTime DateTime=""/>
        <SpecificConditionType>2</SpecificConditionType>
   </SpecificConditionRecord>
  </SpecificConditionRecords>
</SpecificConditions>
```
