### PR TITLE
Use universal, sortable date and time string

### DIFF
--- a/DataFile.cs
+++ b/DataFile.cs
@@ -252,7 +252,7 @@ namespace DataFileReader
 			dailyPresenceCounter=reader.ReadBCDString(2);
 			distance=reader.ReadSInt16();
 
-			writer.WriteAttributeString("DateTime", recordDate.ToString());
+			writer.WriteAttributeString("DateTime", recordDate.ToString("u"));
 			writer.WriteAttributeString("DailyPresenceCounter", dailyPresenceCounter.ToString());
 			writer.WriteAttributeString("Distance", distance.ToString());
 
@@ -622,7 +622,7 @@ namespace DataFileReader
 		{
 			dateTime=reader.ReadTimeReal();
 
-			writer.WriteAttributeString("DateTime", dateTime.ToString());
+			writer.WriteAttributeString("DateTime", dateTime.ToString("u"));
 		}
 
 		public override string ToString()
@@ -647,7 +647,7 @@ namespace DataFileReader
             if (year > 0 || month > 0 || day > 0)
             {
                 dateTime = new DateTime((int)year, (int)month, (int)day);
-                dateTimeString = dateTime.ToString();
+                dateTimeString = dateTime.ToString("u");
             }
 
             writer.WriteAttributeString("Datef", dateTimeString);


### PR DESCRIPTION
`DateTime.ToString()` uses locale dependent format which isn't good to later parse it back if you've different locale...

So it's much better to use one standard format UniversalSortableDateTimePattern ("u")

This will always make dates in format like '2018-03-29 14:00:00Z"'
