### PR TITLE
Skip to the end of CyclicalActivityRegion after it's done

### DIFF
--- a/DataFile.cs
+++ b/DataFile.cs
@@ -232,6 +232,8 @@ namespace DataFileReader
 				// }
 			}
 
+			reader.BaseStream.Position = position + effectiveLength;
+
 			writer.WriteElementString("DataBufferIsWrapped", cyclicStream.Wrapped.ToString());
 		}
 	}


### PR DESCRIPTION

I think it's good idea that all regions always read till end of it as it makes debugging easier.
Currently `CyclicalActivityRegion` might stay in middle of region and depends on `ElementaryFileRegion` that it will read remaining bytes.
