### PR TITLE
Separate serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ Once you have a reader instance you can give it a binary file to read and an XML
 vudf.Process("file.ddd", writer);
 ```
 
+Or alternativly you can work with proccessed regions directly, like
+
+```c#
+vudf.Process(ddd);
+var transferDataOverview = (IdentifiedObjectRegion)vudf.ProcessedRegions.Where(r => r.Name == "TransferDataOverview").First();
+var vehicleIdentificationNumber = transferDataOverview.ProcessedRegions["VehicleIdentificationNumber"];
+```
+
+
 The project tachograph-reader.csproj is suitable for using with .NET Core and VScode, and contains a simple command line app. Run the command without args to scan ./data/vehicle and ./data/driver and process all files found.
 Run the command with --driver <driverfile> or --vehicle <vehiclefile> to process individual files. You can also specify an output filename for the resulting XML. Tasks are set up in VScode for running the command.
 

--- a/src/regions/ActivityChangeRegion.cs
+++ b/src/regions/ActivityChangeRegion.cs
@@ -22,7 +22,9 @@ namespace DataFileReader
 		Activity activity;
 		uint time;
 
-		protected override void ProcessInternal(CustomBinaryReader reader, XmlWriter writer)
+		long position;
+
+		protected override void ProcessInternal(CustomBinaryReader reader)
 		{
 			// format: scpaattt tttttttt (16 bits)
 			// s = slot, c = crew status, p = card inserted, a = activity, t = time
@@ -37,23 +39,29 @@ namespace DataFileReader
 
 			if ( this.LogLevel == LogLevel.DEBUG || this.LogLevel == LogLevel.INFO )
 			{
-				long position=reader.BaseStream.Position;
+				this.position=reader.BaseStream.Position;
 				if ( reader.BaseStream is CyclicStream )
-					position=((CyclicStream) reader.BaseStream).ActualPosition;
-
-				writer.WriteAttributeString("FileOffset", string.Format("0x{0:X4}", position));
+					this.position=((CyclicStream) reader.BaseStream).ActualPosition;
 			}
-			writer.WriteAttributeString("Slot", slot.ToString());
-			writer.WriteAttributeString("Status", status.ToString());
-			writer.WriteAttributeString("Inserted", inserted.ToString());
-			writer.WriteAttributeString("Activity", activity.ToString());
-			writer.WriteAttributeString("Time", string.Format("{0:d2}:{1:d2}", time / 60, time % 60));
 		}
 
 		public override string ToString()
 		{
 			return string.Format("slot={0}, status={1}, inserted={2}, activity={3}, time={4:d2}:{5:d2}",
 				slot, status, inserted, activity, time / 60, time % 60);
+		}
+
+		protected override void InternalToXML(XmlWriter writer)
+		{
+			if ( this.LogLevel == LogLevel.DEBUG || this.LogLevel == LogLevel.INFO )
+			{
+				writer.WriteAttributeString("FileOffset", string.Format("0x{0:X4}", this.position));
+			}
+			writer.WriteAttributeString("Slot", slot.ToString());
+			writer.WriteAttributeString("Status", status.ToString());
+			writer.WriteAttributeString("Inserted", inserted.ToString());
+			writer.WriteAttributeString("Activity", activity.ToString());
+			writer.WriteAttributeString("Time", string.Format("{0:d2}:{1:d2}", time / 60, time % 60));
 		}
 
 	}

--- a/src/regions/BCDStringRegion.cs
+++ b/src/regions/BCDStringRegion.cs
@@ -11,15 +11,19 @@ namespace DataFileReader
 		public int Size;
 		private uint value;
 
-		protected override void ProcessInternal(CustomBinaryReader reader, XmlWriter writer)
+		protected override void ProcessInternal(CustomBinaryReader reader)
 		{
 			value=reader.ReadBCDString(Size);
-			writer.WriteString(value.ToString());
 		}
 
 		public override string ToString()
 		{
 			return value.ToString();
+		}
+
+		protected override void InternalToXML(XmlWriter writer)
+		{
+			writer.WriteString(value.ToString());
 		}
 	}
 }

--- a/src/regions/CardNumberRegion.cs
+++ b/src/regions/CardNumberRegion.cs
@@ -10,22 +10,25 @@ namespace DataFileReader
 		protected byte replacementIndex;
 		protected byte renewalIndex;
 
-		protected override void ProcessInternal(CustomBinaryReader reader, XmlWriter writer)
+		protected override void ProcessInternal(CustomBinaryReader reader)
 		{
 			driverIdentification=reader.ReadString(14);
 			replacementIndex=reader.ReadByte();
 			renewalIndex=reader.ReadByte();
-
-			writer.WriteAttributeString("ReplacementIndex", replacementIndex.ToString());
-			writer.WriteAttributeString("RenewalIndex", renewalIndex.ToString());
-
-			writer.WriteString(driverIdentification);
 		}
 
 		public override string ToString()
 		{
 			return string.Format("{0}, {1}, {2}",
 				driverIdentification, replacementIndex, renewalIndex);
+		}
+
+		protected override void InternalToXML(XmlWriter writer)
+		{
+			writer.WriteAttributeString("ReplacementIndex", replacementIndex.ToString());
+			writer.WriteAttributeString("RenewalIndex", renewalIndex.ToString());
+
+			writer.WriteString(driverIdentification);
 		}
 	}
 }

--- a/src/regions/CodePageStringRegion.cs
+++ b/src/regions/CodePageStringRegion.cs
@@ -57,7 +57,7 @@ namespace DataFileReader
 		{
 		}
 
-		protected override void ProcessInternal(CustomBinaryReader reader, XmlWriter writer)
+		protected override void ProcessInternal(CustomBinaryReader reader)
 		{
 			// get the codepage
 			var codepage = reader.ReadByte();
@@ -81,7 +81,6 @@ namespace DataFileReader
 
 			// read string using encoding
 			base.ProcessInternal(reader, enc);
-			writer.WriteString(text);
 		}
 	}
 }

--- a/src/regions/ContainerRegion.cs
+++ b/src/regions/ContainerRegion.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Xml;
 using System.Xml.Serialization;
 using DataFileReader;
@@ -10,15 +11,20 @@ namespace DataFileReader
 	/// where this is indicated in the specification
 	public class ContainerRegion : Region
 	{
+		[XmlIgnore]
 		public ArrayList regions=new ArrayList();
 
-		protected override void ProcessInternal(CustomBinaryReader reader, XmlWriter writer)
+		[XmlIgnore]
+		public Dictionary<string, Region> ProcessedRegions {get; private set;} = new Dictionary<string, Region>();
+
+		protected override void ProcessInternal(CustomBinaryReader reader)
 		{
 			// iterate over all child regions and process them
 			foreach ( Region r in regions )
 			{
 				r.RegionLength=regionLength;
-				r.Process(reader, writer);
+				r.Process(reader);
+				this.ProcessedRegions.Add(r.Name, r);
 			}
 		}
 
@@ -49,6 +55,14 @@ namespace DataFileReader
 		{
 			get { return regions; }
 			set { regions = value; }
+		}
+
+		protected override void InternalToXML(XmlWriter writer)
+		{
+			foreach (var region in this.ProcessedRegions.Values)
+			{
+				region.ToXML(writer);
+			};
 		}
 	}
 }

--- a/src/regions/CountryRegion.cs
+++ b/src/regions/CountryRegion.cs
@@ -7,10 +7,11 @@ namespace DataFileReader
 	public class CountryRegion : Region
 	{
 		private string countryName;
+		private byte byteValue;
 
-		protected override void ProcessInternal(CustomBinaryReader reader, XmlWriter writer)
+		protected override void ProcessInternal(CustomBinaryReader reader)
 		{
-			byte byteValue=reader.ReadByte();
+			this.byteValue = reader.ReadByte();
 			if ( byteValue < countries.Length )
 				countryName=countries[byteValue];
 			else if (byteValue == 0xFD)
@@ -21,14 +22,17 @@ namespace DataFileReader
 				countryName="World";
 			else
 				countryName="UNKNOWN";
-
-			writer.WriteAttributeString("Name", countryName);
-			writer.WriteString(byteValue.ToString());
 		}
 
 		public override string ToString()
 		{
 			return countryName;
+		}
+
+		protected override void InternalToXML(XmlWriter writer)
+		{
+			writer.WriteAttributeString("Name", this.ToString());
+			writer.WriteString(this.byteValue.ToString());
 		}
 	}
 }

--- a/src/regions/DatefRegion.cs
+++ b/src/regions/DatefRegion.cs
@@ -9,26 +9,32 @@ namespace DataFileReader
 	{
 		private DateTime dateTime;
 
-		protected override void ProcessInternal(CustomBinaryReader reader, XmlWriter writer)
+		protected override void ProcessInternal(CustomBinaryReader reader)
 		{
 			uint year = reader.ReadBCDString(2);
 			uint month = reader.ReadBCDString(1);
 			uint day = reader.ReadBCDString(1);
 
-			string dateTimeString = null;
 			// year 0, month 0, day 0 means date isn't set
 			if (year > 0 || month > 0 || day > 0)
 			{
 				dateTime = new DateTime((int)year, (int)month, (int)day);
-				dateTimeString = dateTime.ToString("u");
 			}
-
-			writer.WriteAttributeString("Datef", dateTimeString);
 		}
 
 		public override string ToString()
 		{
 			return string.Format("{0}", dateTime);
+		}
+
+		protected override void InternalToXML(XmlWriter writer)
+		{
+			string dateTimeString = null;
+			if (this.dateTime != null)
+			{
+				dateTimeString = this.dateTime.ToString("u");
+			};
+			writer.WriteAttributeString("Datef", dateTimeString);
 		}
 	}
 }

--- a/src/regions/ElementaryFileRegion.cs
+++ b/src/regions/ElementaryFileRegion.cs
@@ -13,7 +13,7 @@ namespace DataFileReader
 			return type == 0x01;
 		}
 
-		protected override void ProcessInternal(CustomBinaryReader reader, XmlWriter writer)
+		protected override void ProcessInternal(CustomBinaryReader reader)
 		{
 			// read the type
 			byte type=reader.ReadByte();
@@ -29,7 +29,7 @@ namespace DataFileReader
 			{
 				long start=reader.BaseStream.Position;
 
-				base.ProcessInternal(reader, writer);
+				base.ProcessInternal(reader);
 
 				long amountProcessed=reader.BaseStream.Position-start;
 				fileLength -= amountProcessed;

--- a/src/regions/ExtendedSerialNumberRegion.cs
+++ b/src/regions/ExtendedSerialNumberRegion.cs
@@ -14,7 +14,7 @@ namespace DataFileReader
 		private byte type;
 		private byte manufacturerCode;
 
-		protected override void ProcessInternal(CustomBinaryReader reader, XmlWriter writer)
+		protected override void ProcessInternal(CustomBinaryReader reader)
 		{
 			serialNumber=reader.ReadSInt32();
 			// BCD coding of Month (two digits) and Year (two last digits)
@@ -24,19 +24,22 @@ namespace DataFileReader
 
 			month = (byte)(monthYear / 100);
 			year = (byte)(monthYear % 100);
-
-			writer.WriteAttributeString("Month", month.ToString());
-			writer.WriteAttributeString("Year", year.ToString());
-			writer.WriteAttributeString("Type", type.ToString());
-			writer.WriteAttributeString("ManufacturerCode", manufacturerCode.ToString());
-
-			writer.WriteString(serialNumber.ToString());
 		}
 
 		public override string ToString()
 		{
 			return string.Format("{0}, {1}/{2}, type={3}, manuf code={4}",
 				serialNumber, month, year, type, manufacturerCode);
+		}
+
+		protected override void InternalToXML(XmlWriter writer)
+		{
+			writer.WriteAttributeString("Month", month.ToString());
+			writer.WriteAttributeString("Year", year.ToString());
+			writer.WriteAttributeString("Type", type.ToString());
+			writer.WriteAttributeString("ManufacturerCode", manufacturerCode.ToString());
+
+			writer.WriteString(serialNumber.ToString());
 		}
 	}
 }

--- a/src/regions/FlagRegion.cs
+++ b/src/regions/FlagRegion.cs
@@ -9,15 +9,19 @@ namespace DataFileReader
 	{
 		private bool boolValue;
 
-		protected override void ProcessInternal(CustomBinaryReader reader, XmlWriter writer)
+		protected override void ProcessInternal(CustomBinaryReader reader)
 		{
 			boolValue=reader.ReadByte() > 0;
-			writer.WriteString(boolValue.ToString());
 		}
 
 		public override string ToString()
 		{
 			return boolValue.ToString();
+		}
+
+		protected override void InternalToXML(XmlWriter writer)
+		{
+			writer.WriteString(this.ToString());
 		}
 	}
 }

--- a/src/regions/FullCardNumberRegion.cs
+++ b/src/regions/FullCardNumberRegion.cs
@@ -18,21 +18,26 @@ namespace DataFileReader
 		EquipmentType type;
 		byte issuingMemberState;
 
-		protected override void ProcessInternal(CustomBinaryReader reader, XmlWriter writer)
+		protected override void ProcessInternal(CustomBinaryReader reader)
 		{
 			type=(EquipmentType) reader.ReadByte();
 			issuingMemberState=reader.ReadByte();
 
-			writer.WriteAttributeString("Type", type.ToString());
-			writer.WriteAttributeString("IssuingMemberState", issuingMemberState.ToString());
-
-			base.ProcessInternal(reader, writer);
+			base.ProcessInternal(reader);
 		}
 
 		public override string ToString()
 		{
 			return string.Format("type={0}, {1}, {2}, {3}, {4}",
 				type, issuingMemberState, driverIdentification, replacementIndex, renewalIndex);
+		}
+
+		protected override void InternalToXML(XmlWriter writer)
+		{
+			writer.WriteAttributeString("Type", type.ToString());
+			writer.WriteAttributeString("IssuingMemberState", issuingMemberState.ToString());
+
+			base.InternalToXML(writer);
 		}
 	}
 }

--- a/src/regions/HexValueRegion.cs
+++ b/src/regions/HexValueRegion.cs
@@ -12,14 +12,12 @@ namespace DataFileReader
 		public int Length;
 		private byte[] values;
 
-		protected override void ProcessInternal(CustomBinaryReader reader, XmlWriter writer)
+		protected override void ProcessInternal(CustomBinaryReader reader)
 		{
 			values=new byte[Length];
 
 			for ( int n=0; n< Length; n++ )
 				values[n]=reader.ReadByte();
-
-			writer.WriteAttributeString("Value", this.ToString());
 		}
 
 		public override string ToString()
@@ -38,6 +36,11 @@ namespace DataFileReader
 				sb.AppendFormat("{0:X2}", b);
 
 			return sb.ToString();
+		}
+
+		protected override void InternalToXML(XmlWriter writer)
+		{
+			writer.WriteAttributeString("Value", this.ToString());
 		}
 
 	}

--- a/src/regions/PaddingRegion.cs
+++ b/src/regions/PaddingRegion.cs
@@ -11,7 +11,7 @@ namespace DataFileReader
 		[XmlAttribute]
 		public int Size;
 
-		protected override void ProcessInternal(CustomBinaryReader reader, XmlWriter writer)
+		protected override void ProcessInternal(CustomBinaryReader reader)
 		{
 			byte[] buf=new byte[Size];
 			int amountRead=reader.Read(buf, 0, Size);
@@ -24,5 +24,9 @@ namespace DataFileReader
 			return string.Format("{0} bytes (0x{0:X4})", Size);
 		}
 
+		protected override void InternalToXML(XmlWriter writer)
+		{
+			writer.WriteAttributeString("Size", this.Size.ToString());
+		}
 	}
 }

--- a/src/regions/RepeatingRegion.cs
+++ b/src/regions/RepeatingRegion.cs
@@ -13,7 +13,7 @@ namespace DataFileReader
 		[XmlAttribute]
 		public string CountRef;
 
-		protected override void ProcessInternal(CustomBinaryReader reader, XmlWriter writer)
+		protected override void ProcessInternal(CustomBinaryReader reader)
 		{
 			if ( Count == 0 && CountRef != null )
 			{
@@ -26,7 +26,7 @@ namespace DataFileReader
 					WriteLine(LogLevel.WARN, "RepeatingRegion {0} doesn't contain ref {1}", Name, refName);
 				}
 			}
-			ProcessItems(reader, writer, Count);
+			ProcessItems(reader, Count);
 		}
 	}
 }

--- a/src/regions/SimpleStringRegion.cs
+++ b/src/regions/SimpleStringRegion.cs
@@ -29,11 +29,10 @@ namespace DataFileReader
 			text=s.ReadString(Length, enc).Trim();
 		}
 
-		protected override void ProcessInternal(CustomBinaryReader reader, XmlWriter writer)
+		protected override void ProcessInternal(CustomBinaryReader reader)
 		{
 			// we just use the default encoding in the default case
 			this.ProcessInternal(reader, Encoding.ASCII);
-			writer.WriteString(text);
 		}
 
 		public override string ToString()
@@ -41,5 +40,9 @@ namespace DataFileReader
 			return text;
 		}
 
+		protected override void InternalToXML(XmlWriter writer)
+		{
+			writer.WriteString(this.ToString());
+		}
 	}
 }

--- a/src/regions/TimeRealRegion.cs
+++ b/src/regions/TimeRealRegion.cs
@@ -9,16 +9,19 @@ namespace DataFileReader
 	{
 		private DateTime dateTime;
 
-		protected override void ProcessInternal(CustomBinaryReader reader, XmlWriter writer)
+		protected override void ProcessInternal(CustomBinaryReader reader)
 		{
 			dateTime=reader.ReadTimeReal();
-
-			writer.WriteAttributeString("DateTime", dateTime.ToString("u"));
 		}
 
 		public override string ToString()
 		{
 			return string.Format("{0}", dateTime);
+		}
+
+		protected override void InternalToXML(XmlWriter writer)
+		{
+			writer.WriteAttributeString("DateTime", dateTime.ToString("u"));
 		}
 	}
 }

--- a/src/regions/UInt16Region.cs
+++ b/src/regions/UInt16Region.cs
@@ -8,15 +8,19 @@ namespace DataFileReader
 	{
 		private uint uintValue;
 
-		protected override void ProcessInternal(CustomBinaryReader reader, XmlWriter writer)
+		protected override void ProcessInternal(CustomBinaryReader reader)
 		{
 			uintValue=reader.ReadSInt16();
-			writer.WriteString(uintValue.ToString());
 		}
 
 		public override string ToString()
 		{
 			return uintValue.ToString();
+		}
+
+		protected override void InternalToXML(XmlWriter writer)
+		{
+			writer.WriteString(this.ToString());
 		}
 	}
 }

--- a/src/regions/UInt24Region.cs
+++ b/src/regions/UInt24Region.cs
@@ -9,15 +9,19 @@ namespace DataFileReader
 	{
 		private uint uintValue;
 
-		protected override void ProcessInternal(CustomBinaryReader reader, XmlWriter writer)
+		protected override void ProcessInternal(CustomBinaryReader reader)
 		{
 			uintValue=reader.ReadSInt24();
-			writer.WriteString(uintValue.ToString());
 		}
 
 		public override string ToString()
 		{
 			return uintValue.ToString();
+		}
+
+		protected override void InternalToXML(XmlWriter writer)
+		{
+			writer.WriteString(this.ToString());
 		}
 	}
 }

--- a/src/regions/UInt8Region.cs
+++ b/src/regions/UInt8Region.cs
@@ -8,15 +8,19 @@ namespace DataFileReader
 	{
 		private byte byteValue;
 
-		protected override void ProcessInternal(CustomBinaryReader reader, XmlWriter writer)
+		protected override void ProcessInternal(CustomBinaryReader reader)
 		{
 			byteValue=reader.ReadByte();
-			writer.WriteString(byteValue.ToString());
 		}
 
 		public override string ToString()
 		{
 			return byteValue.ToString();
+		}
+
+		protected override void InternalToXML(XmlWriter writer)
+		{
+			writer.WriteString(this.ToString());
 		}
 	}
 }


### PR DESCRIPTION
This PR separates data processing and XML serialization to individual steps as suggested in #13 
This allows to use processed data directly without needing to write and parse XML.
It's backwards compatible as it doesn't change existing functionality.

I've also included #39 in here.
