### PR TITLE
Validate certitifcate endOfValidity based on newest time we encountered

### DIFF
--- a/src/DataFile.cs
+++ b/src/DataFile.cs
@@ -65,6 +65,7 @@ namespace DataFileReader
 		protected override void ProcessInternal(CustomBinaryReader reader)
 		{
 			WriteLine(LogLevel.DEBUG, "Processing...");
+			SignatureRegion.Reset();
 			Validator.Reset();
 
 			var unmatchedRegions=0;
@@ -141,7 +142,7 @@ namespace DataFileReader
 				}
 			}
 
-			Validator.CheckIfValidated();
+			Validator.CheckIfValidated(SignatureRegion.newestDateTime);
 			WriteLine(LogLevel.DEBUG, "Processing done.");
 		}
 

--- a/src/Exception.cs
+++ b/src/Exception.cs
@@ -24,4 +24,11 @@ namespace DataFileReader
 		}
 	}
 
+	public class ExpiredCertificateException : InvalidSignatureException
+	{
+		public ExpiredCertificateException(string message) : base(message)
+		{
+		}
+	}
+
 }

--- a/src/regions/DriverCardDailyActivityRegion.cs
+++ b/src/regions/DriverCardDailyActivityRegion.cs
@@ -22,6 +22,7 @@ namespace DataFileReader
 			previousRecordLength=reader.ReadSInt16();
 			currentRecordLength=reader.ReadSInt16();
 			recordDate=reader.ReadTimeReal();
+			SignatureRegion.UpdateTime(recordDate);
 			dailyPresenceCounter=reader.ReadBCDString(2);
 			distance=reader.ReadSInt16();
 

--- a/src/regions/ElementaryFileRegion.cs
+++ b/src/regions/ElementaryFileRegion.cs
@@ -41,7 +41,7 @@ namespace DataFileReader
 				long currentOffset = reader.BaseStream.Position;
 
 				reader.BaseStream.Position = SignatureRegion.signedDataOffsetBegin;
-				Validator.ValidateDelayedGen1(reader.ReadBytes(SignatureRegion.GetSignedDataLength()), this.signature);
+				Validator.ValidateDelayedGen1(reader.ReadBytes(SignatureRegion.GetSignedDataLength()), this.signature, () => { return SignatureRegion.newestDateTime; } );
 
 				reader.BaseStream.Position = currentOffset;
 			}

--- a/src/regions/SignatureRegion.cs
+++ b/src/regions/SignatureRegion.cs
@@ -10,6 +10,31 @@ namespace DataFileReader
 	{
 		public static long signedDataOffsetBegin {get; set;} = 0;
 		public static long signedDataOffsetEnd {get; set;} = 0;
+		public static DateTimeOffset? newestDateTime {get; set;} = null;
+
+		public static void Reset()
+		{
+			SignatureRegion.signedDataOffsetBegin = 0;
+			SignatureRegion.signedDataOffsetEnd = 0;
+			SignatureRegion.newestDateTime = null;
+		}
+
+		public static void UpdateTime(DateTime dateTime)
+		{
+			SignatureRegion.UpdateTime((DateTimeOffset)DateTime.SpecifyKind(dateTime, DateTimeKind.Utc));
+		}
+
+		public static void UpdateTime(DateTimeOffset dateTime)
+		{
+
+			if (SignatureRegion.newestDateTime == null ||
+			    (dateTime > SignatureRegion.newestDateTime.Value &&
+			     // need to compare to current time to filter out dateTime from future...
+			     dateTime < DateTimeOffset.Now))
+			{
+				SignatureRegion.newestDateTime = dateTime;
+			}
+		}
 
 		public static int GetSignedDataLength()
 		{
@@ -25,7 +50,7 @@ namespace DataFileReader
 			long currentOffset = reader.BaseStream.Position;
 
 			reader.BaseStream.Position = SignatureRegion.signedDataOffsetBegin;
-			Validator.ValidateGen1(reader.ReadBytes(SignatureRegion.GetSignedDataLength()), this.ToBytes());
+			Validator.ValidateGen1(reader.ReadBytes(SignatureRegion.GetSignedDataLength()), this.ToBytes(), SignatureRegion.newestDateTime);
 
 			reader.BaseStream.Position = currentOffset;
 		}

--- a/src/regions/TimeRealRegion.cs
+++ b/src/regions/TimeRealRegion.cs
@@ -12,6 +12,7 @@ namespace DataFileReader
 		protected override void ProcessInternal(CustomBinaryReader reader)
 		{
 			dateTime=reader.ReadTimeReal();
+			SignatureRegion.UpdateTime(dateTime);
 		}
 
 		public override string ToString()


### PR DESCRIPTION
Previously we validated `Certitifcate.endOfValidity` by using current time, but that's not really right approach because we might validate old file signed with old certificate which now is expired but wasn't expired when that file was created.

So this PR implements validating `Certitifcate.endOfValidity` time against newest (biggest) time we encounter present in file. This way we can see if file doesn't contain any data signed with old/expired certificate. For example signed file where any time is after certificate's `endOfValidity` will fail validation.
