### PR TITLE
Decode CardIccIdentification.EmbedderIcAssemblerId

### DIFF
--- a/src/DriverCardData.config
+++ b/src/DriverCardData.config
@@ -6,10 +6,13 @@
 		<ExtendedSerialNumber Name="CardExtendedSerialNumber"/>
 		<SimpleString Name="CardApprovalNumber" Length="8"/>
 		<UInt8 Name="CardPersonaliserId" Length="1"/>
-		<SimpleString Name="EmbedderIcAssemblerId" Length="5"/>
+		<Object Name="EmbedderIcAssemblerId">
+			<SimpleString Name="CountryCode" Length="2" />
+			<BCDString Name="ModuleEmbedder" Size="2" />
+			<UInt8 Name="ManufacturerInformation" Length="1" />
+		</Object>
 		<UInt16 Name="IcIdentifier" Length="2"/>
 	</ElementaryFile>
-
 
 	<ElementaryFile Name="CardChipIdentification" Identifier="0x0005" Unsigned="true">
 		<HexValue Name="IcSerialNumber" Length="4"/>


### PR DESCRIPTION
`EmbedderIcAssemblerId` isn't `SimpleString(5)` but

![attels](https://user-images.githubusercontent.com/651800/65245935-3820e280-daf6-11e9-9710-e2e48fabc613.png)

![attels](https://user-images.githubusercontent.com/651800/65245992-55ee4780-daf6-11e9-8014-a0e1014cb750.png)
